### PR TITLE
Fix TextBody to render correctly in prod. builds when directly visiting links to posts

### DIFF
--- a/src/components/TextBody.js
+++ b/src/components/TextBody.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { BREAKPOINT } from '../utils/constants';
 
-export const TextBody = styled.p`
+export const TextBody = styled.div`
   color: var(--dark-color-light);
   display: block;
   letter-spacing: -0.003em;


### PR DESCRIPTION
**Problem Description:**
When visiting a link to a blog post directly in production, for example: [https://lewis-gatsby-starter-blog.netlify.app/blog/post3/](https://lewis-gatsby-starter-blog.netlify.app/blog/post3/), the post body represented by `post.html` in the response to the GraphQL query, is not visible until the site has been reloaded or cached by the browser.

<img width="1440" alt="Screen Shot 2020-05-19 at 11 22 35 PM" src="https://user-images.githubusercontent.com/20888153/82405124-ffdcf580-9a30-11ea-8119-734a6c55fe22.png">


**Fix Suggested:**
The issue at gatsbyjs/gatsby#11108 helped in the solution _ie._ by replacing the `p` with a `div` as the root level styled component of `TextBody`.